### PR TITLE
Needed addition for available_plugins to load the library-directory

### DIFF
--- a/core/analysis_scripts/analysis_scripts/plugins.py
+++ b/core/analysis_scripts/analysis_scripts/plugins.py
@@ -87,7 +87,7 @@ def _plugin_object(name):
     raise ValueError(f"could not find compatible object in {name}.") 
 
 
-def available_plugins(library_directory):
+def available_plugins(library_directory=None):
     """Returns a list of plugin names."""
     find_plugins(library_directory)
     return sorted(list(discovered_plugins.keys()))

--- a/core/analysis_scripts/analysis_scripts/plugins.py
+++ b/core/analysis_scripts/analysis_scripts/plugins.py
@@ -87,8 +87,9 @@ def _plugin_object(name):
     raise ValueError(f"could not find compatible object in {name}.") 
 
 
-def available_plugins():
+def available_plugins(library_directory):
     """Returns a list of plugin names."""
+    find_plugins(library_directory)
     return sorted(list(discovered_plugins.keys()))
 
 


### PR DESCRIPTION
Currently, `available_plugins` does not detect the custom `library-directory` location for the plugins.

Passing in the `library-directory` to run `find_plugins` works as expected.

With the change in this working example, where `freanalysis_land` was installed into `/local2/home/python`.

(fre-2024.01) c2b:~/git/fre-cli%>fre analysis list --library-directory /local2/home/python  
['freanalysis_land']

Without this, listing will never work as it cannot see the custom directory.

(fre-2024.01) c2b:~/git/fre-cli%>fre analysis list 
[]
