### PR TITLE
Minor adjustments to mdtf plugin

### DIFF
--- a/user-analysis-scripts/freanalysis_MDTF/pyproject.toml
+++ b/user-analysis-scripts/freanalysis_MDTF/pyproject.toml
@@ -9,7 +9,7 @@ name = "freanalysis_MDTF"
 version = "0.1"
 dependencies = [
     "setuptools",
-    "MDTF-diagnostics@git+https://github.com/jtmims/MDTF-diagnostics@pip_refactor",
+    "MDTF-diagnostics@git+https://github.com/NOAA-GFDL/MDTF-diagnostics@pip_refactor",
 ]
 requires-python = ">= 3.6"
 authors = [

--- a/user-analysis-scripts/freanalysis_MDTF/tests/test.py
+++ b/user-analysis-scripts/freanalysis_MDTF/tests/test.py
@@ -5,12 +5,15 @@ print(available_plugins())
 
 # run the 'example' MDTF POD
 name = "freanalysis_MDTF"  # name of the custom analysis script you want to run
-catalog_path = '/local/home/Jacob.Mims/djptest/mdtf/catalog.json' # absolute path to catalog .json file
-out_dir = '/local/home/Jacob.Mims/analysistest/' # absolute path to dir that you would like the MDTF to run and output
+catalog_path = "/work/c2b/freanalysis_MDTF/catalog.json" # absolute path to catalog .json file
+out_dir = "/work/c2b/freanalysis_MDTF_output" # absolute path to dir that you would like the MDTF to run and output
 config={
-    'pods': ['example'], # list of pods you'd like to run
+    'pods': ['Wheeler_Kiladis'], # list of pods you'd like to run
     'startyr': '1990', # year to start analysis
-    'endyr': '1995' # year to end analysis
+    'endyr': '1995', # year to end analysis
+    'custom_pod_info_json': "",
+    'data_range': [1990, 1995],
+    'use_gfdl_mdtf_env': True
 }
 figures = run_plugin(name, catalog_path, out_dir, config=config)
 print(figures)


### PR DESCRIPTION
- `fre analysis install` presently requires analysis plugins to be pip installable, and MDTF is not yet pip installable. @jtmims made MDTF pip installable just for this purpose, but the updates are not yet merged to MDTF's trunk. Until then, let's point to the MDTF repo branch with the proposed pip changes.
- Minor updates to the associated test.py script to make it work without changes at gfdl